### PR TITLE
Fix Xcode linking 08-18+

### DIFF
--- a/COpenSSL/include/module.modulemap
+++ b/COpenSSL/include/module.modulemap
@@ -1,4 +1,4 @@
 module COpenSSL {
 	header "openssl.h"
-	link "COpenSSL"
+	link framework "COpenSSL"
 }


### PR DESCRIPTION
This small change seems to allow me to build in Xcode as well as command line. Currently, Xcode builds are choking on Linker w/ snapshot `08-18`