### PR TITLE
removed link line from modulemap

### DIFF
--- a/COpenSSL/include/module.modulemap
+++ b/COpenSSL/include/module.modulemap
@@ -1,4 +1,3 @@
 module COpenSSL {
 	header "openssl.h"
-	link "COpenSSL"
 }


### PR DESCRIPTION
swift 4 will not build an executable with this line included. Swift 3.1 has no problem building a project if this line is removed.