### PR TITLE
Expose x509v3.h

### DIFF
--- a/COpenSSL/include/openssl.h
+++ b/COpenSSL/include/openssl.h
@@ -4,6 +4,7 @@
 #include "../ssl.h"
 #include "../sha.h"
 #include "../x509.h"
+#include "../x509v3.h"
 #include "../hmac.h"
 #include "../rand.h"
 #include "../cms.h"


### PR DESCRIPTION
`x509v3.h` is referenced from several other C files in the code, but the functions and structures are not exposed.

In our project, specifically, we use the `GEN_EMAIL` constant and the `GENERAL_NAME` struct from `x509v3.h`